### PR TITLE
Extended Regex and added Javascript example

### DIFF
--- a/regex.js
+++ b/regex.js
@@ -1,0 +1,46 @@
+const regexPattern = /(?<norm_type>§+|Art|Artikel)\.?\s*(?<norm>\d+(?:\w\b)?)\s*(?:Absatz|Abs\.\s*(?<absatz>\d+(?:\w\b)?))?\s*(?:Satz|S\.\s*(?<satz>\d+))?\s*(?:Nummer|Nr\.\s*(?<nr>\d+(?:\w\b)?))?\s*(?:Buchstabe|Buchst\.|lit\.\s*(?<lit>[a-z]?))?.{0,10}?(?<gesetz>\b[A-Z][A-Za-z]*[A-Z](?:(?<buch>(?:\s|\b)[XIV]+)?))/g;
+
+// Helper function to transform the law object back to a string.
+function createLawObj(matchGroups) {
+  return {
+    norm_type: matchGroups.norm_type,
+    norm: matchGroups.norm,
+    absatz: matchGroups.absatz ? `Absatz ${matchGroups.absatz}` : undefined,
+    satz: matchGroups.satz ? `Satz ${matchGroups.satz}` : undefined,
+    nr: matchGroups.nr ? `Nummer ${matchGroups.nr}` : undefined,
+    lit: matchGroups.lit ? `Buchst. ${matchGroups.lit}` : undefined,
+    gesetz: matchGroups.buch ? `${matchGroups.gesetz} ${matchGroups.buch}` : matchGroups.gesetz,
+  };
+}
+
+// Main function
+function getLaws(query) {
+  const data = [];
+  const uniqueLaws = new Set();
+  let match;
+  
+  // Matching with the regex pattern
+  while ((match = regexPattern.exec(query)) !== null) {
+    const lawObj = createLawObj(match.groups);
+    const lawString = Object.values(lawObj).filter(Boolean).join(' ');
+
+    // Prevent duplicate laws
+    if (!uniqueLaws.has(lawString)) {
+      uniqueLaws.add(lawString);
+      data.push({match, law_obj: lawObj, law_string: lawString});
+    }
+
+    // Prevent infinite loops with zero-length matches
+    if (regexPattern.lastIndex === match.index) {
+      regexPattern.lastIndex++;
+    }
+  }
+
+  return data;
+}
+
+// Example
+query = "Gemäß §1 BGB und §1 BGB, sowie §2 Abs. 2 UStG, §3 Abs. 3 Satz 4 EstG, Artikel 1 GG, usw...";
+for (law of getLaws(query)) {
+  console.log(law.law_string);
+}

--- a/regex.py
+++ b/regex.py
@@ -5,12 +5,12 @@ import re
 
 # Für Erläuterung der Regex siehe README.md
 p = re.compile(r""" # Die Regex wird in p kompiliert
-(§+|Art|Artikel)\.?\s*
+(?P<norm_type>§+|Art|Artikel)\.?\s*
 (?P<norm>\d+(?:\w\b)?)\s*
-(?:Abs\.\s*(?P<absatz>\d+(?:\w\b)?))?\s*
-(?:S\.\s*(?P<satz>\d+))?\s*
-(?:Nr\.\s*(?P<nr>\d+(?:\w\b)?))?\s*
-(?:lit\.\s*(?P<lit>[a-z]?))?
+(?:Absatz|Abs\.\s*(?P<absatz>\d+(?:\w\b)?))?\s*
+(?:Satz|S\.\s*(?P<satz>\d+))?\s*
+(?:Nummer|Nr\.\s*(?P<nr>\d+(?:\w\b)?))?\s*
+(?:Buchstabe|Buchst\.lit\.\s*(?P<lit>[a-z]?))?
 .{0,10}?
 (?P<gesetz>\b[A-Z][A-Za-z]*[A-Z](?:(?P<buch>(?:\s|\b)[XIV]+)?))
 """, re.VERBOSE)

--- a/regex_alternative.py
+++ b/regex_alternative.py
@@ -5,14 +5,14 @@ import re
 
 # Für Erläuterung der Regex siehe README.md
 p = re.compile(r""" # Die Regex wird in p kompiliert
-(§+|Art|Artikel)\.?\s*
+(?P<norm_type>§+|Art|Artikel)\.?\s*
 (?P<norm>\d+(?:\w\b)?)\s*
-(?:Abs\.\s*(?P<absatz>\d+(?:\w\b)?))?\s*
-(?:S\.\s*(?P<satz>\d+))?\s*
-(?:Nr\.\s*(?P<nr>\d+(?:\w\b)?))?\s*
-(?:lit\.\s*(?P<lit>[a-z]?))?
+(?:Absatz|Abs\.\s*(?P<absatz>\d+(?:\w\b)?))?\s*
+(?:Satz|S\.\s*(?P<satz>\d+))?\s*
+(?:Nummer|Nr\.\s*(?P<nr>\d+(?:\w\b)?))?\s*
+(?:Buchstabe|Buchst\.lit\.\s*(?P<lit>[a-z]?))?
 .{0,10}?
-(?P<gesetz>zpo|versg|egzpo)(?![\w-])
+(?P<gesetz>\b[A-Z][A-Za-z]*[A-Z](?:(?P<buch>(?:\s|\b)[XIV]+)?))
 """, re.IGNORECASE | re.VERBOSE)
 
 Teststring = """Hier zu überprüfenden Text einfügen"""

--- a/regex_alternative.py
+++ b/regex_alternative.py
@@ -12,7 +12,7 @@ p = re.compile(r""" # Die Regex wird in p kompiliert
 (?:Nummer|Nr\.\s*(?P<nr>\d+(?:\w\b)?))?\s*
 (?:Buchstabe|Buchst\.lit\.\s*(?P<lit>[a-z]?))?
 .{0,10}?
-(?P<gesetz>\b[A-Z][A-Za-z]*[A-Z](?:(?P<buch>(?:\s|\b)[XIV]+)?))
+(?P<gesetz>zpo|versg|egzpo)(?![\w-])
 """, re.IGNORECASE | re.VERBOSE)
 
 Teststring = """Hier zu überprüfenden Text einfügen"""


### PR DESCRIPTION
Hi there! Thought this would be helpful for others as well. All changes are non-breaking, maintaining backward compatibility.

Regex:
- Added ‘Absatz’, ‘Satz’, ‘Nummer’, ‘Buchstabe’, ‘Buchst.’ to Regex, so it finds matches better.
- Added ‘norm_type’ group to Regex for easier construction of a string.

JavaScript:
- Added a JavaScript example.
- The JS function also returns an additional object 'law_Obj' for easier readability.
- The JS function also returns 'law_string' that is used for deduplication and allows for better readability (vs. the objects).